### PR TITLE
Longest Common Prefix

### DIFF
--- a/lib/leet_code_problems/prefixer.ex
+++ b/lib/leet_code_problems/prefixer.ex
@@ -1,0 +1,25 @@
+defmodule LeetCodeProblems.Prefixer do
+  @spec longest_common(strs :: [String.t()]) :: String.t()
+  def longest_common(strs) do
+    # strs = ["flower","flow","flight"] => "fl"
+    list = Enum.map(strs, &String.to_charlist(&1))
+
+    solution =
+      case list do
+        [head] ->
+          head
+
+        [head | tail] ->
+          Enum.reduce(tail, head, fn s, acc ->
+            solver(s, acc, []) |> Enum.reverse()
+          end)
+      end
+
+    List.to_string(solution)
+  end
+
+  defp solver([head1 | tail1], [head2 | tail2], solution) when head1 == head2,
+    do: solver(tail1, tail2, [head1 | solution])
+
+  defp solver(_list1, _list2, solution), do: solution
+end


### PR DESCRIPTION
Write a function to find the longest common prefix string amongst an array of strings.

If there is no common prefix, return an empty string "".

**Example 1:**
```
Input: strs = ["flower","flow","flight"]
Output: "fl"
```

**Example 2:**
```
Input: strs = ["dog","racecar","car"]
Output: ""
```
Explanation: There is no common prefix among the input strings.
 

**Constraints:**
```
1 <= strs.length <= 200
0 <= strs[i].length <= 200
strs[i] consists of only lowercase English letters.
```