### PR TITLE
Matrix Diagonal Sum

### DIFF
--- a/lib/leet_code_problems/matrix.ex
+++ b/lib/leet_code_problems/matrix.ex
@@ -1,0 +1,22 @@
+defmodule LeetCodeProblems.Matrix do
+  require Integer
+
+  @spec diagonal_sum(mat :: [[integer]]) :: integer
+  def diagonal_sum(mat) do
+    n = length(mat) - 1
+
+    {_index, solutions} =
+      Enum.reduce(mat, {0, []}, fn array, {index, values} ->
+        value_1 = Enum.at(array, index)
+        value_2 = Enum.at(array, n - index)
+
+        if Integer.is_even(n) and div(n, 2) == index do
+          {index + 1, [value_1 | values]}
+        else
+          {index + 1, [value_1, value_2 | values]}
+        end
+      end)
+
+    Enum.sum(solutions)
+  end
+end


### PR DESCRIPTION
Given a square matrix mat, return the sum of the matrix diagonals.

Only include the sum of all the elements on the primary diagonal and all the elements on the secondary diagonal that are not part of the primary diagonal.

![image](https://user-images.githubusercontent.com/34007453/236790931-fffb5dc1-a74a-422e-b712-70f26b6e28e5.png)

**Example 1:**
```
Input: mat = [[1,2,3],
              [4,5,6],
              [7,8,9]]
Output: 25
```
Explanation: Diagonals sum: 1 + 5 + 9 + 3 + 7 = 25
Notice that element mat[1][1] = 5 is counted only once.

**Example 2:**
```
Input: mat = [[1,1,1,1],
              [1,1,1,1],
              [1,1,1,1],
              [1,1,1,1]]
Output: 8
```

**Example 3:**
```
Input: mat = [[5]]
Output: 5
```

**Constraints:**
```
n == mat.length == mat[i].length
1 <= n <= 100
1 <= mat[i][j] <= 100
```