### PR TITLE
Roman to Integer

### DIFF
--- a/lib/leet_code_problems/roman_numbers.ex
+++ b/lib/leet_code_problems/roman_numbers.ex
@@ -1,0 +1,40 @@
+defmodule LeetCodeProblems.RomanNumbers do
+  @spec to_integer(s :: String.t()) :: integer
+  def to_integer(s) do
+    s |> String.codepoints() |> solver(0)
+  end
+
+  defp solver([], solution), do: solution
+
+  defp solver(["I", head | rest], solution) do
+    cond do
+      head == "V" -> solver(rest, solution + 4)
+      head == "X" -> solver(rest, solution + 9)
+      true -> solver([head | rest], solution + 1)
+    end
+  end
+
+  defp solver(["X", head | rest], solution) do
+    cond do
+      head == "L" -> solver(rest, solution + 40)
+      head == "C" -> solver(rest, solution + 90)
+      true -> solver([head | rest], solution + 10)
+    end
+  end
+
+  defp solver(["C", head | rest], solution) do
+    cond do
+      head == "D" -> solver(rest, solution + 400)
+      head == "M" -> solver(rest, solution + 900)
+      true -> solver([head | rest], solution + 100)
+    end
+  end
+
+  defp solver(["I" | rest], solution), do: solver(rest, solution + 1)
+  defp solver(["V" | rest], solution), do: solver(rest, solution + 5)
+  defp solver(["X" | rest], solution), do: solver(rest, solution + 10)
+  defp solver(["L" | rest], solution), do: solver(rest, solution + 50)
+  defp solver(["C" | rest], solution), do: solver(rest, solution + 100)
+  defp solver(["D" | rest], solution), do: solver(rest, solution + 500)
+  defp solver(["M" | rest], solution), do: solver(rest, solution + 1000)
+end


### PR DESCRIPTION
Roman numerals are represented by seven different symbols: I, V, X, L, C, D and M.

```
Symbol       Value
I             1
V             5
X             10
L             50
C             100
D             500
M             1000
```
For example, 2 is written as II in Roman numeral, just two ones added together. 12 is written as XII, which is simply X + II. The number 27 is written as XXVII, which is XX + V + II.

Roman numerals are usually written largest to smallest from left to right. However, the numeral for four is not IIII. Instead, the number four is written as IV. Because the one is before the five we subtract it making four. The same principle applies to the number nine, which is written as IX. There are six instances where subtraction is used:

I can be placed before V (5) and X (10) to make 4 and 9. 
X can be placed before L (50) and C (100) to make 40 and 90. 
C can be placed before D (500) and M (1000) to make 400 and 900.
Given a roman numeral, convert it to an integer.

 

Example 1:

```
Input: s = "III"
Output: 3
```
Explanation: III = 3.
Example 2:

```
Input: s = "LVIII"
Output: 58
```
Explanation: L = 50, V= 5, III = 3.
Example 3:

```
Input: s = "MCMXCIV"
Output: 1994
```
Explanation: M = 1000, CM = 900, XC = 90 and IV = 4.
 

**Constraints:**
```
1 <= s.length <= 15
s contains only the characters ('I', 'V', 'X', 'L', 'C', 'D', 'M').
It is guaranteed that s is a valid roman numeral in the range [1, 3999].
```