### PR TITLE
Uncrossed Lines

### DIFF
--- a/lib/leet_code_problems/linex.ex
+++ b/lib/leet_code_problems/linex.ex
@@ -1,0 +1,51 @@
+defmodule LeetCodeProblems.Linex do
+  @spec max_uncrossed_lines(nums1 :: [integer], nums2 :: [integer]) :: integer
+  def max_uncrossed_lines(nums1, nums2) do
+    # We could first caculate all possible pairs and then
+    {pair_indexes, max} = Enum.zip(nums1, nums2) |> Enum.with_index() |> solver([], 0)
+    # subtract for each crossed index
+    subtract(pair_indexes, max)
+  end
+
+  defp subtract(pair_indexes, solution) do
+    {pair_indexes, solution}
+  end
+
+  def solver([{{num, num}, index} | rest], pair_indexes, acc),
+    do: solver(rest, [{index, index} | pair_indexes], acc + 1)
+
+  def solver([{{num1, num2}, index} | rest], pair_indexes, acc) do
+    case {find(num1, index, rest, :down), find(num2, index, rest, :up)} do
+      {{}, {}} -> solver(rest, pair_indexes, acc)
+      {{}, pair} -> solver(rest, [pair | pair_indexes], acc + 1)
+      {pair, {}} -> solver(rest, [pair | pair_indexes], acc + 1)
+      {pair1, pair2} -> solver(rest, [pair1, pair2 | pair_indexes], acc + 2)
+    end
+  end
+
+  defp find(_num, _index, [], _direction), do: {}
+
+  defp find(num, index, [{{_up_num, num}, down_index} | _rest], :down) do
+    {index, down_index}
+  end
+
+  defp find(num, index, [{{num, _down_num}, up_index} | _rest], :up) do
+    {up_index, index}
+  end
+
+  defp find(num, index, [_head | rest], direction), do: find(num, index, rest, direction)
+end
+
+#   1   4   5   3   2
+#   I
+#   1   3   7   2   4
+
+#   4   2   1   5   3
+#
+#   5   3   1   4   6
+
+# 0:
+# 1:
+# 2:
+# 3:
+# 4:


### PR DESCRIPTION
You are given two integer arrays nums1 and nums2. We write the integers of nums1 and nums2 (in the order they are given) on two separate horizontal lines.

We may draw connecting lines: a straight line connecting two numbers nums1[i] and nums2[j] such that:

nums1[i] == nums2[j], and
the line we draw does not intersect any other connecting (non-horizontal) line.
Note that a connecting line cannot intersect even at the endpoints (i.e., each number can only belong to one connecting line).

Return the maximum number of connecting lines we can draw in this way.

 

**Example 1:**
![image](https://github.com/ken-kost/leet_code_problems/assets/34007453/f45c21d8-563b-4168-a584-a37906dd8608)

```
Input: nums1 = [1,4,2], nums2 = [1,2,4]
Output: 2
```

Explanation: We can draw 2 uncrossed lines as in the diagram.
We cannot draw 3 uncrossed lines, because the line from nums1[1] = 4 to nums2[2] = 4 will intersect the line from nums1[2]=2 to nums2[1]=2.

**Example 2:**
```
Input: nums1 = [2,5,1,2,5], nums2 = [10,5,2,1,5,2]
Output: 3
```

**Example 3:**
```
Input: nums1 = [1,3,7,1,7,5], nums2 = [1,9,2,5,1]
Output: 2
```
 

**Constraints:**
```
1 <= nums1.length, nums2.length <= 500
1 <= nums1[i], nums2[j] <= 2000
```