### PR TITLE
Merge Two Sorted Lists

### DIFF
--- a/lib/leet_code_problems/sorted_lists.ex
+++ b/lib/leet_code_problems/sorted_lists.ex
@@ -1,0 +1,49 @@
+defmodule LeetCodeProblems.ListNode do
+  @type t :: %__MODULE__{
+          val: integer,
+          next: ListNode.t() | nil
+        }
+  defstruct val: 0, next: nil
+end
+
+defmodule LeetCodeProblems.SortedLists do
+  # Definition for singly-linked list.
+  #
+
+  # The following arguments were given to Solution.solver/3:
+  # # 1
+  # %ListNode{next: %ListNode{next: %ListNode{next: nil, val: 4}, val: 2}, val: 1}
+  # # 2
+  # %ListNode{next: %ListNode{next: %ListNode{next: nil, val: 4}, val: 3}, val: 1}
+  # # 3
+  # []
+
+  alias LeetCodeProblems.ListNode
+
+  @spec merge(list1 :: ListNode.t() | nil, list2 :: ListNode.t() | nil) ::
+          ListNode.t() | nil
+  def merge(list1, list2) do
+    solver(list1, list2, [])
+  end
+
+  defp solver(nil, nil, solution), do: solution |> Enum.reverse() |> to_map()
+
+  defp solver(%ListNode{next: next_node, val: val}, nil, solution),
+    do: solver(next_node, nil, [val | solution])
+
+  defp solver(nil, %ListNode{next: next_node, val: val}, solution),
+    do: solver(nil, next_node, [val | solution])
+
+  defp solver(%ListNode{next: next, val: val}, %ListNode{next: _, val: bigger} = node, solution)
+       when val <= bigger,
+       do: solver(next, node, [val | solution])
+
+  defp solver(%ListNode{next: _, val: _} = node, %ListNode{next: next_node, val: val}, solution),
+    do: solver(node, next_node, [val | solution])
+
+  defp to_map([]), do: nil
+
+  defp to_map([head | rest]) do
+    %ListNode{next: to_map(rest), val: head}
+  end
+end


### PR DESCRIPTION
You are given the heads of two sorted linked lists list1 and list2.

Merge the two lists in a one sorted list. The list should be made by splicing together the nodes of the first two lists.

Return the head of the merged linked list.

**Example 1:**
![image](https://github.com/ken-kost/leet_code_problems/assets/34007453/3d81153b-6285-4d3e-af61-73771dc6f45d)
```
Input: list1 = [1,2,4], list2 = [1,3,4]
Output: [1,1,2,3,4,4]
```

**Example 2:**
```
Input: list1 = [], list2 = []
Output: []
```

**Example 3:**
```
Input: list1 = [], list2 = [0]
Output: [0]
```
 

**Constraints:**
```
The number of nodes in both lists is in the range [0, 50].
-100 <= Node.val <= 100
Both list1 and list2 are sorted in non-decreasing order.
```